### PR TITLE
Update package topper for the `extra-wide` theme

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -99,8 +99,7 @@ const usePackageTopper = (content) => {
 		},
 		'extra-wide': {
 			bgColour: 'slate',
-			// TODO: Find out if the App uses an `extra-wide` theme
-			layout: 'full-bleed-offset',
+			layout: 'split-text-left',
 			largeHeadline: true
 		}
 	};

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -190,11 +190,11 @@ describe('Get topper settings', () => {
 			});
 
 			expect(topper).to.deep.include({
-				layout: 'full-bleed-offset',
+				layout: 'split-text-left',
 				largeHeadline: true,
 				backgroundColour: 'slate',
 				modifiers: [
-					'full-bleed-offset',
+					'split-text-left',
 					'package',
 					'package-extra-wide'
 				]


### PR DESCRIPTION
Until recently, `o-topper` was only used by `ft-app`. `next-article` had its own (similar) implementation. I updated `next-article` to use `o-topper` and noticed a different topper applies to an `extra-wide` theme on each platform. The app uses a `split-left-text` topper. FT.com uses a `full-bleed-offset` topper.

We had two options:

1. Use the same topper for both platforms when an `extra-wide` theme applies.
2. Use different toppers which would require adding some logic in `n-map-content-topper`, `next-article` or `ft-app` to implement this.

[After talking to the Design Team (Josh)](https://financialtimes.slack.com/archives/C335G1G5R/p1601289376003800), we decided on option 1 and have both platforms use the `split-left-text` topper. Option 1 is simpler and makes sense considering Content Innovation plans on having a larger conversation about article toppers with Origami.

**FT.com Before**
![image](https://user-images.githubusercontent.com/30316203/94427540-25b89a80-0187-11eb-94f2-67da693a1b93.png)

**FT.com After**
![image](https://user-images.githubusercontent.com/30316203/94427472-0cafe980-0187-11eb-8a65-439d9bc3470f.png)