### PR TITLE
CI-358 Add settings for the live blog v2 topper 

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -6,7 +6,8 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'6da31a37-691f-4908-896f-2829ebe2309e'
+			'isLiveBlogV1OrPackage', // src/lib/get-topper-settings.js:18|234
+			'6da31a37-691f-4908-896f-2829ebe2309e' // src/lib/get-topper-settings.js:46, test/lib/get-topper-settings.test.js:291|309
 		]
 	}
 };

--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -10,10 +10,13 @@ const isNews = (content) =>
 	content.annotations &&
 	content.annotations.some((annotation) => annotation.prefLabel === 'News');
 
+const isLiveBlogV1 = (content) =>
+	content.type === 'live-blog' && content.realtime;
+
 const isLiveBlogV2 = (content) => content.type === 'live-blog-package';
 
-const isLiveBlogOrPackage = (content) =>
-	(content.realtime && content.liveBlog) ||
+const isLiveBlogV1OrPackage = (content) =>
+	isLiveBlogV1(content) ||
 	(content.package &&
 		isNews(content.package) &&
 		content.package.contains[0].id === content.id) ||
@@ -51,15 +54,14 @@ const useLiveBlogV2 = () => {
 		largeHeadline: true,
 		backgroundColour: 'paper',
 		modifiers: ['full-bleed-offset']
-	}
+	};
 };
 
-const useLiveBlogOrPackageTopper = (content, flags) => {
+const useLiveBlogV1OrPackageTopper = (content, flags) => {
 	const designTheme =
 		(content.package && content.package.design.theme) ||
 		(content.design && content.design.theme);
-	const isStandaloneLiveBlog =
-		!content.package && content.realtime && content.liveBlog;
+	const isStandaloneLiveBlog = isLiveBlogV1(content);
 
 	const isLoud =
 		designTheme === 'extra' ||
@@ -229,8 +231,8 @@ const getTopperSettings = (content, flags = {}) => {
 
 	if (isLiveBlogV2(content)) {
 		return useLiveBlogV2();
-	} else if (isLiveBlogOrPackage(content)) {
-		return useLiveBlogOrPackageTopper(content, flags);
+	} else if (isLiveBlogV1OrPackage(content)) {
+		return useLiveBlogV1OrPackageTopper(content, flags);
 	} else if (isPackageArticlesWithExtraTheme(content)) {
 		return useExtraThemeTopper();
 	} else if (isPackage(content)) {

--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -10,6 +10,8 @@ const isNews = (content) =>
 	content.annotations &&
 	content.annotations.some((annotation) => annotation.prefLabel === 'News');
 
+const isLiveBlogV2 = (content) => content.type === 'live-blog-package';
+
 const isLiveBlogOrPackage = (content) =>
 	(content.realtime && content.liveBlog) ||
 	(content.package &&
@@ -42,6 +44,14 @@ const isBranded = (content) =>
 
 const followPlusDigestEmail = (flags) => {
 	return flags.onboardingMessaging === 'followPlusEmailDigestTooltip';
+};
+
+const useLiveBlogV2 = () => {
+	return {
+		largeHeadline: true,
+		backgroundColour: 'paper',
+		modifiers: ['full-bleed-offset']
+	}
 };
 
 const useLiveBlogOrPackageTopper = (content, flags) => {
@@ -217,7 +227,9 @@ const useBrandedTopper = (content, flags) => {
 const getTopperSettings = (content, flags = {}) => {
 	content.topper = content.topper || {};
 
-	if (isLiveBlogOrPackage(content)) {
+	if (isLiveBlogV2(content)) {
+		return useLiveBlogV2();
+	} else if (isLiveBlogOrPackage(content)) {
 		return useLiveBlogOrPackageTopper(content, flags);
 	} else if (isPackageArticlesWithExtraTheme(content)) {
 		return useExtraThemeTopper();

--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -11,6 +11,11 @@ const isNews = (content) =>
 	content.annotations.some((annotation) => annotation.prefLabel === 'News');
 
 const isLiveBlogV1 = (content) =>
+	/**
+	 * The `live-blog` content type is not used in Elasticsearch. The content type is
+	 * overridden from `article` to `live-blog` in `next-article` here:
+	 * https://github.com/Financial-Times/next-article/blob/574581adc200e60051e3ca9c7fd5e9a6e16cee82/server/controllers/content.js#L29-L32
+	 */
 	content.type === 'live-blog' && content.realtime;
 
 const isLiveBlogV2 = (content) => content.type === 'live-blog-package';

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -20,8 +20,8 @@ describe('Get topper settings', () => {
 	describe('Live blog', () => {
 		it('returns the live blog v1 topper', () => {
 			const topper = getTopperSettings({
+				type: 'live-blog',
 				realtime: true,
-				liveBlog: { status: 'inprogress' }
 			});
 
 			expect(topper).to.deep.include({

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -18,7 +18,7 @@ describe('Get topper settings', () => {
 	});
 
 	describe('Live blog', () => {
-		it('returns the live blog topper', () => {
+		it('returns the live blog v1 topper', () => {
 			const topper = getTopperSettings({
 				realtime: true,
 				liveBlog: { status: 'inprogress' }
@@ -31,6 +31,18 @@ describe('Get topper settings', () => {
 					variant: 'monochrome',
 					followPlusDigestEmail: false
 				}
+			});
+		});
+
+		it('returns the live blog v2 topper', () => {
+			const topper = getTopperSettings({
+				type: 'live-blog-package'
+			});
+
+			expect(topper).to.deep.include({
+				largeHeadline: true,
+				backgroundColour: 'paper',
+				modifiers: ['full-bleed-offset']
 			});
 		});
 	});


### PR DESCRIPTION
We're replacing the live blog topper on the App and FT.com. This pull request checks for the new live blog type (v2) and returns the correct topper settings (eg. background colour, modifiers etc). Topper settings are eventually passed to each platform and the correct toppers are rendered.