### PR TITLE
Change the background color to use wheat to help the layout feel less like a mistake

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -142,16 +142,16 @@ const useEditoriallySelectedTopper = (content) => {
 
 	// Convert old palette colours to new palette colours from Methode
 	if (content.topper.layout === 'full-bleed-offset') {
-		backgroundColour = 'paper';
+		backgroundColour = 'wheat';
 	} else if (
 		content.topper.backgroundColour === 'pink' ||
 		content.topper.backgroundColour === 'auto'
 	) {
-		backgroundColour = 'paper';
+		backgroundColour = 'wheat';
 	} else if (content.topper.backgroundColour === 'blue') {
 		backgroundColour = 'oxford';
 	} else {
-		backgroundColour = content.topper.backgroundColour || 'paper';
+		backgroundColour = content.topper.backgroundColour || 'wheat';
 	}
 
 	return {

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -223,18 +223,18 @@ describe('Get topper settings', () => {
 			expect(topper).to.deep.include({
 				layout: 'full-bleed-offset',
 				largeHeadline: true,
-				backgroundColour: 'paper',
+				backgroundColour: 'wheat',
 				modifiers: ['full-bleed-offset'],
 				includesImage: true
 			});
 		});
 
-		it('sets the `backgroundColour` to `paper` if undefined', () => {
+		it('sets the `backgroundColour` to `wheat` if undefined', () => {
 			const topper = getTopperSettings({
 				topper: { layout: 'split-text-center' }
 			});
 
-			expect(topper.backgroundColour).to.equal('paper');
+			expect(topper.backgroundColour).to.equal('wheat');
 		});
 	});
 


### PR DESCRIPTION
We've had a request from design to update the topper to use a wheat background instead of paper.

From the #design-ops channel
>A few designers have raised this before: The background colour of this topper is our paper, which makes the layout feel like a mistake due to the lack of contrast between topper and body. Is there a way we can replace all with our darker BG version of this topper and retire this paper one?
> -- https://financialtimes.slack.com/archives/C01481FKWA2/p1607509313182400

I originally thought this change would be in next-article but it turns out next-article gets the styles from this package :-D

I tested this by running next-article locally and linking n-map-content-to-topper to my local next-article.

The screenshot below is of the locally running next-article with this n-map-content-to-topper change.

<img width="1406" alt="image" src="https://user-images.githubusercontent.com/1569131/101629970-1329cf80-3a1a-11eb-86ad-0a125f6b62d2.png">


Please let me know if I need to change anything else for this to be approved :-)