### PR TITLE
Map live blogs to a topper layout

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -34,11 +34,12 @@ const followPlusDigestEmail = (flags) => {
 	return flags.onboardingMessaging === 'followPlusEmailDigestTooltip';
 };
 
-const useLiveBlogV2 = () => {
+const useLiveBlogV2 = (content) => {
 	return {
 		largeHeadline: true,
 		backgroundColour: 'paper',
-		modifiers: ['full-bleed-offset']
+		modifiers: ['full-bleed-offset'],
+		layout: (content.topper && content.topper.layout) ? content.topper.layout : 'full-bleed-offset'
 	};
 };
 
@@ -190,7 +191,7 @@ const getTopperSettings = (content, flags = {}) => {
 	content.topper = content.topper || {};
 
 	if (isLiveBlogV2(content)) {
-		return useLiveBlogV2();
+		return useLiveBlogV2(content);
 	} else if (isPackageArticlesWithExtraTheme(content)) {
 		return useExtraThemeTopper();
 	} else if (isPackage(content)) {

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -29,6 +29,31 @@ describe('Get topper settings', () => {
 				modifiers: ['full-bleed-offset']
 			});
 		});
+
+		describe('When a layout exists', () => {
+			it('uses the layout', () => {
+				const topper = getTopperSettings({
+					type: 'live-blog-package',
+					topper: {
+						layout: 'example-layout'
+					}
+				});
+
+				expect(topper.layout).to.equal('example-layout');
+			});
+		});
+
+		describe('When a layout does NOT exists', () => {
+			it('defaults the layout', () => {
+				const topper = getTopperSettings({
+					type: 'live-blog-package'
+				});
+
+				expect(topper.layout).to.equal('full-bleed-offset');
+			});
+		});
+
+
 	});
 
 	describe('Package articles with an `extra` theme', () => {


### PR DESCRIPTION
Now that the architecture in next-article is the same for live blogs as other articles we need to map toppers in the same way.

This fixes a case where the images where missing from the live blog toppers because it was missing the layout property which is used to define the themeImageRatio property which is then used by next-article to choose the image markup