### PR TITLE
Update to node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ references:
   container_config_node12: &container_config_node12
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:16.14.2-browsers
 
   container_config_lambda_node12: &container_config_lambda_node12
     working_directory: ~/project/build

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/Financial-Times/n-map-content-to-topper/issues"
   },
   "homepage": "https://github.com/Financial-Times/n-map-content-to-topper#readme",
+  "engines": {
+    "node": "16.x"
+  },
   "devDependencies": {
     "@financial-times/n-gage": "^8.2.0",
     "bower": "^1.8.8",
@@ -30,5 +33,9 @@
       "commit-msg": "secret-squirrel-commitmsg",
       "pre-push": "make verify -j3"
     }
+  },
+  "volta": {
+    "node": "16.14.2",
+    "npm": "7.20.2"
   }
 }


### PR DESCRIPTION
[Ticket.](https://financialtimes.atlassian.net/browse/CI-1073)

This PR:
- Updates package.json and CircleCI config to use Node 16 as part of the migration away from Node 12.