### PR TITLE
change build-tes-provision in order to need approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
 
-  container_config_node12: &container_config_node12
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: cimg/node:16.14.2-browsers
@@ -52,18 +52,18 @@ references:
     branches:
       only: /(^renovate-.*|^nori/.*)/
 
-  filters_ignore_tags_renovate_nori: &filters_ignore_tags_renovate_nori
+  filters_ignore_tags_renovate_nori_main: &filters_ignore_tags_renovate_nori_main
     tags:
       ignore: /.*/
     branches:
-      ignore: /(^renovate-.*|^nori/.*)/
+      ignore: /(^renovate-.*|^nori/.*|^main)/
 
-version: 2
+version: 2.1
 
 jobs:
 
   build:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -109,7 +109,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -130,12 +130,26 @@ workflows:
   build-test:
     jobs:
       - build:
+          name: build-no-main
           filters:
-            <<: *filters_ignore_tags_renovate_nori
+            <<: *filters_ignore_tags_renovate_nori_main
       - test:
+          name : test-no-main
           requires:
-            - build
-
+            - build-no-main
+      - wait-for-approval:
+          type: approval
+          filters:
+            <<: *filters_only_renovate_nori
+      - build:
+          name: build-renovate
+          requires:
+            - wait-for-approval
+      - test:
+          name : test-renovate
+          requires:
+            - build-renovate
+            
   build-test-publish:
     jobs:
       - build:


### PR DESCRIPTION

There is an error with the required steps and the configuration on circleCi config.yml that it doesn't allow to merge into main due that build-test-provision job is required . This job should continue to be required in order to guarantee the PR stability.
From Github settings i haven't found a way to only required build-test in some PR an others no , so I've got the solution changing the way we were making the approval for renovate/nori branches.
Instead of creating a new job only for this PRs i have integrated the logic of approval inside the build-test job so always is launched an Github would allows us to merge into main without changing the old behavior
[ticket](https://financialtimes.atlassian.net/browse/CI-1103)