### PR TITLE
add deep-landscape to themeImageRatio full-bleed

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -4,7 +4,8 @@ const themeImageRatio = {
 	'deep-portrait': 'split',
 	'full-bleed-image-center': 'full-bleed',
 	'full-bleed-image-left': 'full-bleed',
-	'full-bleed-offset': 'full-bleed'
+	'full-bleed-offset': 'full-bleed',
+	'deep-landscape': 'full-bleed'
 };
 
 const isLiveBlogV2 = (content) => content.type === 'live-blog-package';


### PR DESCRIPTION
add new topper deep-landscape to full-bleed themeImageRatio
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1409) 