### PR TITLE
feat: support backgroundBox field that changes the background

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -106,7 +106,13 @@ const useEditoriallySelectedTopper = (content) => {
 	if (content.topper.layout === 'full-bleed-offset') {
 		backgroundColour = 'wheat';
 	} else if (content.topper.layout === 'deep-landscape') {
-		if (!hasDarkBackground(content.topper.backgroundColour)) {
+		// If the backgroundBox is present, use its color to determine a background colour
+		// The background color won't be visible due to the overlapping image, however, it's needed to
+		// determine the text color
+		if (content.topper.backgroundBox) {
+			backgroundColour =
+				content.topper.backgroundBox === 'light' ? 'white' : 'black';
+		} else if (!hasDarkBackground(content.topper.backgroundColour)) {
 			backgroundColour = 'white';
 		}
 	} else if (

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -121,6 +121,29 @@ describe('Get topper settings', () => {
 
 			expect(topper.backgroundColour).to.equal('white');
 		});
+
+		describe('When a background Box is present', () => {
+			it('sets the `backgroundColour` to `white` if layout is deep landscape and background Box is light', () => {
+				const topper = getTopperSettings({
+					topper: {
+						layout: 'deep-landscape',
+						backgroundBox: 'light'
+					}
+				});
+
+				expect(topper.backgroundColour).to.equal('white');
+			});
+			it('sets the `backgroundColour` to `black` if layout is deep landscape and background Box is dark', () => {
+				const topper = getTopperSettings({
+					topper: {
+						layout: 'deep-landscape',
+						backgroundBox: 'dark'
+					}
+				});
+
+				expect(topper.backgroundColour).to.equal('black');
+			});
+		});
 	});
 
 	describe('Podcast', () => {


### PR DESCRIPTION
The [approved contract](https://financialtimes.atlassian.net/wiki/spaces/DYN/pages/7993032717/Topper+Background+Box+on+Deep+Landscape) implemented in C&M and Spark introduces a `backgroundBox` field that can be either `light` or `dark`.

When the `backgroundBox` is selected for Deep Landscape, the frontend will always receive the same background color. e.g.:

```
"topper": {
        ...
        "layout": "deep-landscape",
        "backgroundColour": "auto",
        "textShadow": false,
        "backgroundBox": "light"
        ...
    },
``` 
Thus we cannot use the background colour to infer the colour of the text.
As a consequence, the text would always be black, given the current implementation in the CSS.

In this PR, based on the colour of the background box we force a background that will not be visible due to the overlapping image of the theme, but it will lead to the downstream choice of the right text colour.

Related to https://github.com/Financial-Times/origami/pull/1008 
