### PR TITLE
fix backgroundColour set for deep-landscape

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -115,6 +115,10 @@ const useEditoriallySelectedTopper = (content) => {
 		} else if (!hasDarkBackground(content.topper.backgroundColour)) {
 			backgroundColour = 'white';
 		}
+		else{
+			backgroundColour = 'black';
+		}
+		
 	} else if (
 		content.topper.backgroundColour === 'pink' ||
 		content.topper.backgroundColour === 'auto'

--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -114,11 +114,9 @@ const useEditoriallySelectedTopper = (content) => {
 				content.topper.backgroundBox === 'light' ? 'white' : 'black';
 		} else if (!hasDarkBackground(content.topper.backgroundColour)) {
 			backgroundColour = 'white';
-		}
-		else{
+		} else {
 			backgroundColour = 'black';
 		}
-		
 	} else if (
 		content.topper.backgroundColour === 'pink' ||
 		content.topper.backgroundColour === 'auto'

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -122,6 +122,21 @@ describe('Get topper settings', () => {
 			expect(topper.backgroundColour).to.equal('white');
 		});
 
+		it('sets the `backgroundColour` to `black` if layout is deep landscape and background is dark', () => {
+			const topper = getTopperSettings({
+				topper: { layout: 'deep-landscape', backgroundColour: 'slate' }
+			});
+
+			expect(topper.backgroundColour).to.equal('black');
+		});
+		it('sets the `backgroundColour` to `white` if layout is deep landscape and background is undefined', () => {
+			const topper = getTopperSettings({
+				topper: { layout: 'deep-landscape' }
+			});
+
+			expect(topper.backgroundColour).to.equal('white');
+		});
+
 		describe('When a background Box is present', () => {
 			it('sets the `backgroundColour` to `white` if layout is deep landscape and background Box is light', () => {
 				const topper = getTopperSettings({


### PR DESCRIPTION
Why?
We weren't setting the backgroundColour property when the background was dark
Whith this change we fix this
needed to complete this [ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?modal=detail&selectedIssue=CI-1517&search=1517)