### PR TITLE
CI-1543 fix: remove usage of backgroundBox as string

### DIFF
--- a/src/lib/get-topper-settings.js
+++ b/src/lib/get-topper-settings.js
@@ -106,16 +106,10 @@ const useEditoriallySelectedTopper = (content) => {
 	if (content.topper.layout === 'full-bleed-offset') {
 		backgroundColour = 'wheat';
 	} else if (content.topper.layout === 'deep-landscape') {
-		// If the backgroundBox is present, use its color to determine a background colour
-		// The background color won't be visible due to the overlapping image, however, it's needed to
-		// determine the text color
-		if (content.topper.backgroundBox) {
-			backgroundColour =
-				content.topper.backgroundBox === 'light' ? 'white' : 'black';
-		} else if (!hasDarkBackground(content.topper.backgroundColour)) {
-			backgroundColour = 'white';
-		} else {
+		if (hasDarkBackground(content.topper.backgroundColour)) {
 			backgroundColour = 'black';
+		} else {
+			backgroundColour = 'white';
 		}
 	} else if (
 		content.topper.backgroundColour === 'pink' ||

--- a/test/lib/get-topper-settings.test.js
+++ b/test/lib/get-topper-settings.test.js
@@ -114,50 +114,28 @@ describe('Get topper settings', () => {
 			expect(topper.backgroundColour).to.equal('wheat');
 		});
 
-		it('sets the `backgroundColour` to `white` if layout is deep landscape and background is light', () => {
+		it('sets the `backgroundColour` to `white` if layout is deep landscape and the background is auto', () => {
 			const topper = getTopperSettings({
-				topper: { layout: 'deep-landscape', backgroundColour: 'paper' }
+				topper: { layout: 'deep-landscape', backgroundColour: 'auto' }
 			});
 
 			expect(topper.backgroundColour).to.equal('white');
 		});
 
-		it('sets the `backgroundColour` to `black` if layout is deep landscape and background is dark', () => {
+		it('sets the `backgroundColour` to `black` if layout is deep landscape and background is slate', () => {
 			const topper = getTopperSettings({
 				topper: { layout: 'deep-landscape', backgroundColour: 'slate' }
 			});
 
 			expect(topper.backgroundColour).to.equal('black');
 		});
+
 		it('sets the `backgroundColour` to `white` if layout is deep landscape and background is undefined', () => {
 			const topper = getTopperSettings({
 				topper: { layout: 'deep-landscape' }
 			});
 
 			expect(topper.backgroundColour).to.equal('white');
-		});
-
-		describe('When a background Box is present', () => {
-			it('sets the `backgroundColour` to `white` if layout is deep landscape and background Box is light', () => {
-				const topper = getTopperSettings({
-					topper: {
-						layout: 'deep-landscape',
-						backgroundBox: 'light'
-					}
-				});
-
-				expect(topper.backgroundColour).to.equal('white');
-			});
-			it('sets the `backgroundColour` to `black` if layout is deep landscape and background Box is dark', () => {
-				const topper = getTopperSettings({
-					topper: {
-						layout: 'deep-landscape',
-						backgroundBox: 'dark'
-					}
-				});
-
-				expect(topper.backgroundColour).to.equal('black');
-			});
 		});
 	});
 


### PR DESCRIPTION
It was decided to roll back to the idea of the background box field being a boolean rather than a string.

If backgroundBox is present, Spark will store in CAPI a backgroundColour either `slate` or `auto`.

This will reflect in the following logic.

```
// Text colour: white, backgroundBox: on
{ ... backgroundColour: "slate", backgroundBox: true }
// Text colour: white, backgroundBox: off
{ ... backgroundColour: "slate", backgroundBox: false }
// Text colour: black, backgroundBox: on
{ ... backgroundColour: "auto", backgroundBox: true }
// Text colour: black, backgroundBox: off
{ ... backgroundColour: "auto", backgroundBox: false }
```

This PR amend test and code for this. I changed `slate` to `black` and `auto` to `white` to enforce a better look and feel in case the image of the topper would not load.

We could simplify our code and remove the statement for deep-landscape, but we will get `wheat` or `slate`.


