### PR TITLE
Remove snyk [automated]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.379.2
-ignore: {}
-patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
 				"husky": "^8.0.0",
 				"mocha": "^8.1.1",
 				"proxyquire": "^2.1.3",
-				"sinon": "^9.0.3",
-				"snyk": "^1.379.2"
+				"sinon": "^9.0.3"
 			},
 			"engines": {
 				"node": "18.x || 20.x",
@@ -678,85 +677,6 @@
 				"read-package-json-fast": "^2.0.1"
 			}
 		},
-		"node_modules/@sentry-internal/tracing": {
-			"version": "7.112.2",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.112.2.tgz",
-			"integrity": "sha512-fT1Y46J4lfXZkgFkb03YMNeIEs2xS6jdKMoukMFQfRfVvL9fSWEbTgZpHPd/YTT8r2i082XzjtAoQNgklm/0Hw==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/core": "7.112.2",
-				"@sentry/types": "7.112.2",
-				"@sentry/utils": "7.112.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/core": {
-			"version": "7.112.2",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.2.tgz",
-			"integrity": "sha512-gHPCcJobbMkk0VR18J65WYQTt3ED4qC6X9lHKp27Ddt63E+MDGkG6lvYBU1LS8cV7CdyBGC1XXDCfor61GvLsA==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/types": "7.112.2",
-				"@sentry/utils": "7.112.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/integrations": {
-			"version": "7.112.2",
-			"resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.112.2.tgz",
-			"integrity": "sha512-ioC2yyU6DqtLkdmWnm87oNvdn2+9oKctJeA4t+jkS6JaJ10DcezjCwiLscX4rhB9aWJV3IWF7Op0O6K3w0t2Hg==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/core": "7.112.2",
-				"@sentry/types": "7.112.2",
-				"@sentry/utils": "7.112.2",
-				"localforage": "^1.8.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/node": {
-			"version": "7.112.2",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.112.2.tgz",
-			"integrity": "sha512-MNzkqER8jc2xOS3ArkCLH5hakzu15tcjeC7qjU7rQ1Ms4WuV+MG0docSRESux0/p23Qjzf9tZOc8C5Eq+Sxduw==",
-			"dev": true,
-			"dependencies": {
-				"@sentry-internal/tracing": "7.112.2",
-				"@sentry/core": "7.112.2",
-				"@sentry/integrations": "7.112.2",
-				"@sentry/types": "7.112.2",
-				"@sentry/utils": "7.112.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/types": {
-			"version": "7.112.2",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.2.tgz",
-			"integrity": "sha512-kCMLt7yhY5OkWE9MeowlTNmox9pqDxcpvqguMo4BDNZM5+v9SEb1AauAdR78E1a1V8TyCzjBD7JDfXWhvpYBcQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/utils": {
-			"version": "7.112.2",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.2.tgz",
-			"integrity": "sha512-OjLh0hx0t1EcL4ZIjf+4svlmmP+tHUDGcr5qpFWH78tjmkPW4+cqPuZCZfHSuWcDdeiaXi8TnYoVRqDcJKK/eQ==",
-			"dev": true,
-			"dependencies": {
-				"@sentry/types": "7.112.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1087,12 +1007,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/boolean": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-			"dev": true
 		},
 		"node_modules/bower": {
 			"version": "1.8.14",
@@ -1625,12 +1539,6 @@
 			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
 			"dev": true
 		},
-		"node_modules/detect-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-			"dev": true
-		},
 		"node_modules/diff": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1914,12 +1822,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
 		},
 		"node_modules/escalade": {
 			"version": "3.1.2",
@@ -2495,23 +2397,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/global-agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-			"dev": true,
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"es6-error": "^4.1.1",
-				"matcher": "^3.0.0",
-				"roarr": "^2.15.3",
-				"semver": "^7.3.2",
-				"serialize-error": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=10.0"
-			}
-		},
 		"node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -2795,12 +2680,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/immediate": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"dev": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -3355,12 +3234,6 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true
-		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
@@ -3440,29 +3313,11 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
-		"node_modules/lie": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-			"integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-			"dev": true,
-			"dependencies": {
-				"immediate": "~3.0.5"
-			}
-		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
-		},
-		"node_modules/localforage": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-			"integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-			"dev": true,
-			"dependencies": {
-				"lie": "3.1.1"
-			}
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -3572,18 +3427,6 @@
 			},
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/matcher": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/merge-descriptors": {
@@ -4995,23 +4838,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/roarr": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-			"dev": true,
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"detect-node": "^2.0.4",
-				"globalthis": "^1.0.1",
-				"json-stringify-safe": "^5.0.1",
-				"semver-compare": "^1.0.0",
-				"sprintf-js": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5119,39 +4945,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.13.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/serialize-javascript": {
@@ -5297,23 +5090,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/snyk": {
-			"version": "1.1290.0",
-			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1290.0.tgz",
-			"integrity": "sha512-AD72kAeGZ9f5AguB4S4LnUFrpkCg3fww9pykAiLRkkBT4ueGWsN2QyAwH4tpdxUVs3R1SUnY1OornrBXRFkdNg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"@sentry/node": "^7.36.0",
-				"global-agent": "^3.0.0"
-			},
-			"bin": {
-				"snyk": "bin/snyk"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/socks": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "A library for mapping content to a topper on FT.com and the App",
 	"main": "main.js",
 	"scripts": {
-		"prepare": "npx snyk protect || npx snyk protect -d || true && husky install",
+		"prepare": "husky install",
 		"precommit": "secret-squirrel && npm run format && npm run fix",
 		"prepush": "npm run test",
 		"fix": "eslint '**/*.{js,json,yml}' --fix",
@@ -44,8 +44,7 @@
 		"husky": "^8.0.0",
 		"mocha": "^8.1.1",
 		"proxyquire": "^2.1.3",
-		"sinon": "^9.0.3",
-		"snyk": "^1.379.2"
+		"sinon": "^9.0.3"
 	},
 	"volta": {
 		"node": "18.20.2",


### PR DESCRIPTION
In mid-December 2024 we will be letting our Snyk contract expire. We'll
be moving to GitHub Advanced Security as an alternative.

This PR is an attempt to get ahead of the deadline. Considering how out
of date some of our Snyk implementations are, and that we rarely take
the time to merge the PRs, we think it's fine to remove it way ahead of
time.

If you want an interrim solution, enable Dependabot Security updates for
this repository by visiting the following page and clicking 'Enable' next
to 'Dependabot security updates':
https://github.com/Financial-Times/n-map-content-to-topper/settings/security_analysis

You're also free to ignore this PR and do the work yourself closer to
the deadline. Cyber will be doing some broader comms later in the year.

This PR was automated, please take a little extra care when reviewing. I
won't be attempting to fix build failures or small repo-specific quirks
but feel free to build on top of this PR.